### PR TITLE
feat(tasks/main): Run with `--all-logs` to avoid getting "tailed" files

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -35,13 +35,13 @@
   when: "'sos' not in ansible_facts.packages and satellite_lock is defined and satellite_lock == 'locked'"
 
 - name: "Run sosreport (on < RHEL 8)"
-  command: "sosreport --batch"
+  command: "sosreport --batch --all-logs"
   register: sosreport_cmd
   when:
     - ansible_distribution_major_version | int < 8
 
 - name: "Run sosreport (on >= RHEL 8)"
-  command: "sos report --batch"
+  command: "sos report --batch --all-logs"
   register: sosreport_cmd
   when:
     - ansible_distribution_major_version | int >= 8


### PR DESCRIPTION
We have discovered that by default `sos` only keeps a "tailed" output files that exceed a defined size (as in it will only show the last contents of that file up to that size).

Run the `report` subcomand with `--all-logs` in order to overcome this limitation at the expense of increasing the output file size by a tenfold :S